### PR TITLE
Use touch id for sudo

### DIFF
--- a/modules/darwin.nix
+++ b/modules/darwin.nix
@@ -29,6 +29,13 @@
     ];
     systemPath = ["/opt/homebrew/bin" "/Users/ethan/.npm-global/bin"];
     pathsToLink = ["/Applications"];
+    
+    # use touch id for sudo
+    etc = {
+      "pam.d/sudo_local".text = ''
+        auth sufficient pam_tid.so
+      '';
+    };
   };
   # system.keyboard.enableKeyMapping = true;
   # system.keyboard.remapCapsLockToEscape = true;


### PR DESCRIPTION
Not sure if you want suggestions, but I wanted to thank you for the template!

I found this change useful. Can be changed to `security.pam.enableSudoTouchIdAuth = true;` as soon as the linked PR is merged into nix.

See here for rational: https://github.com/LnL7/nix-darwin/pull/787